### PR TITLE
Fix random new line breaking file paths | Add executable flag to dist/eslint-staged-files.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "bin": "dist/eslint-staged-files.js",
   "es6": "src/eslint-staged-files.js",
   "scripts": {
-    "build": "babel src -d dist --ignore **/__tests__",
+    "build": "babel src -d dist --ignore **/__tests__ && yarn run chmod-dist",
     "prepublishOnly": "yarn run build",
+    "chmod-dist": "chmod a+x dist/eslint-staged-files.js",
     "test": "yarn run test-eslint && yarn run test-jest",
     "test-eslint": "eslint src/ test/ --ext .jsx,.js",
     "test-jest": "jest",

--- a/src/eslint-staged-files.js
+++ b/src/eslint-staged-files.js
@@ -2,11 +2,20 @@
 
 const { exec } = require('child_process');
 
-const gitDiff = exec('git diff --staged --diff-filter=ACMTUXB --name-only', { encoding: 'utf8' });
-
-gitDiff.stdout.on('data', (gitOutput) => {
+exec('git diff --staged --diff-filter=ACMTUXB --name-only', (error, stdout, stderr) => {
+  if (error) {
+    console.error(`exec error: ${error}`);
+    return;
+  }
+  if (stderr) {
+    console.error(`git diff error: ${stderr}`);
+    return;
+  }
+  if (!stdout) {
+    return;
+  }
   // Get the list of staged files
-  const files = gitOutput
+  const files = stdout
     .split('\n')
     .map(path => path.trim())
     .filter(Boolean)
@@ -33,8 +42,4 @@ gitDiff.stdout.on('data', (gitOutput) => {
   eslint.on('close', (code) => {
     process.exit(code);
   });
-});
-
-gitDiff.stderr.on('data', (data) => {
-  console.error(`git diff error: ${data}`);
 });


### PR DESCRIPTION
Add executable flag to dist/eslint-staged-files.js file (fix "npm run test" command for macos)